### PR TITLE
Comment to add github to build settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ markdown:            kramdown
 highlighter:         rouge
 permalink:           none
 plugins:             [jekyll-paginate, jekyll-sitemap, jekyll-feed, jekyll-seo-tag]
+#github:              [metadata]
 
 sass:
   sass_dir: assets/css


### PR DESCRIPTION
Fix the message "GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data." as mentioned in https://github.com/github/pages-gem/issues/399.

Made comment as optional.