### PR TITLE
No header display when exactly at $container-width

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -40,7 +40,7 @@
   Responsiveness with a dropdown menu
 */
 
-@media (min-width: $container-width) {
+@media (min-width: $container-width+1px) {
   .dropbtn {
     display: none;
   }


### PR DESCRIPTION
Thank you for creating Millennial, I’ve been using it for a few years now!

I noticed that when the screen width is exactly 1100px wide ($container-width), the header will not display the menu links, nor the dropdown menu.

This is due to 2 conflicting CSS media queries within [_sass/_header.scss](https://github.com/LeNPaul/Millennial/blob/38541ba61fedaf07ef1e43d08f7ac6b893077017/_sass/_header.scss) at:

https://github.com/LeNPaul/Millennial/blob/38541ba61fedaf07ef1e43d08f7ac6b893077017/_sass/_header.scss#L43
https://github.com/LeNPaul/Millennial/blob/38541ba61fedaf07ef1e43d08f7ac6b893077017/_sass/_header.scss#L51

The issue is that the logic of both queries is inclusive, so when the screen width is exactly equal to $container-width, both queries are trying to add their attributes.

The fix will make it so that when the screen width is exactly $container-width, the dropdown menu will show.